### PR TITLE
Fix: Corrige o overflow da barra de pergunta em telas de celular

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders question input', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const inputElement = screen.getByPlaceholderText(/Faça sua pergunta.../i);
+  expect(inputElement).toBeInTheDocument();
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 html, body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
A barra de 'faça sua pergunta' estava excedendo a largura da tela em dispositivos móveis.

Isso foi resolvido aplicando `box-sizing: border-box` globalmente. Essa regra garante que o `padding` e a `border` sejam incluídos na largura total dos elementos, evitando que o campo de input transborde seu contêiner quando sua largura é definida como `100%` na media query para dispositivos móveis.

Além disso, o teste padrão do `create-react-app` foi atualizado para refletir o conteúdo real da aplicação.