### PR TITLE
Refactor: Remove a exibição duplicada da pergunta

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,9 +95,6 @@ function App() {
           Nova Pergunta
         </button>
 
-        <div className="pergunta-atual">
-          {pergunta && <p>Pergunta: {pergunta}</p>}
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Remove o elemento que exibia a pergunta abaixo do botão 'Nova Pergunta'. Isso evita a redundância, já que a pergunta permanece visível no campo de input.